### PR TITLE
Add `compose/variant`

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -74,8 +74,9 @@
        (call-with-variant (λ () (apply/variant f #:tag n a*)) g))
      composed]))
 
-(define (compose/variant . fs)
-  (for/fold ([acc variant]) ([f (in-list fs)])
+(define (compose/variant . f*)
+  (for/fold ([acc variant])
+            ([f (in-list f*)])
     (compose2/variant acc f)))
 
 

--- a/main.rkt
+++ b/main.rkt
@@ -13,7 +13,8 @@
   (contract-out
    [variant (->* () (#:tag natural?) #:rest (listof any/c) any)]
    [apply/variant (->* (procedure?) (#:tag natural?) #:rest (listof any/c) any)]
-   [call-with-variant (-> (-> any) procedure? any)])
+   [call-with-variant (-> (-> any) procedure? any)]
+   [compose/variant (->* () () #:rest (listof procedure?) procedure?)])
   ;; Export the tag structure type and the helper macros
   (struct-out tag)
   let*-variant
@@ -63,6 +64,19 @@
            (apply/variant receiver #:tag (tag-number t) v*)
            (apply receiver t v*))]))
   (call-with-values generator receiver*))
+
+(define (compose2/variant g f)
+  (cond
+    [(equal? f variant) g]
+    [(equal? g variant) f]
+    [else
+     (define (composed #:tag [n 0] . a*)
+       (call-with-variant (λ () (apply/variant f #:tag n a*)) g))
+     composed]))
+
+(define (compose/variant . fs)
+  (for/fold ([acc variant]) ([f (in-list fs)])
+    (compose2/variant acc f)))
 
 
 (begin-for-syntax

--- a/scribblings/variant.scrbl
+++ b/scribblings/variant.scrbl
@@ -90,6 +90,24 @@ A @tech{variant}-aware version of @racket[call-with-values]. Applies
 ]
 }
 
+@defproc[(compose/variant [proc procedure?] ...*) procedure?]{
+A @tech{variant}-aware version of @racket[compose]. Composes procedures
+with @racket[call-with-variant] so that tags are forwarded between them.
+The rightmost procedure is applied first.
+
+Calling @racket[(compose/variant)] returns @racket[variant], which acts
+as the identity element, so @racket[(compose/variant variant f variant)]
+simply yields @racket[f].
+
+@variant-examples[
+(define add1-tag (λ (x) (variant (add1 x) #:tag 1)))
+(define unwrap (λ (#:tag [n 0] x) (cons x n)))
+((compose/variant unwrap add1-tag) 3)
+(compose/variant add1-tag variant)
+(compose/variant variant add1-tag)
+]
+}
+
 @defform[(let*-variant ([kw-formals rhs-expr] ...) body ...+)
          #:grammar
          [(kw-formals (arg ...)

--- a/scribblings/variant.scrbl
+++ b/scribblings/variant.scrbl
@@ -90,7 +90,7 @@ A @tech{variant}-aware version of @racket[call-with-values]. Applies
 ]
 }
 
-@defproc[(compose/variant [proc procedure?] ...*) procedure?]{
+@defproc[(compose/variant [proc procedure?] ...) procedure?]{
 A @tech{variant}-aware version of @racket[compose]. Composes procedures
 with @racket[call-with-variant] so that tags are forwarded between them.
 The rightmost procedure is applied first.

--- a/tests/variant.rkt
+++ b/tests/variant.rkt
@@ -87,3 +87,31 @@
              (λ ()
                (define-variant (#:tag n v . v*) (variant 1 2 3 #:tag 0))
                (cons (cons v* v) n))))
+
+(test-case "Test `compose/variant'"
+  (define (add1-tag x) (variant (add1 x) #:tag 1))
+  (define (unwrap #:tag [n 0] x) (cons x n))
+  (check-variant=
+   ((compose/variant) #:tag 2 1 2)
+   (variant 1 2 #:tag 2))
+  (check-variant=
+   ((compose/variant add1-tag values) 3)
+   (variant 4 #:tag 1))
+  (check-equal?
+   ((compose/variant unwrap add1-tag) 3)
+   '(4 . 1))
+  (define (inc #:tag [n 0] x) (variant (add1 x) #:tag n))
+  (define (pair #:tag [n 0] x) (cons x n))
+  (check-equal?
+   ((compose/variant pair inc) #:tag 5 1)
+   '(2 . 5))
+  (check-variant=
+   ((compose/variant add1-tag variant) 10)
+   (add1-tag 10))
+  (check-variant=
+   ((compose/variant variant add1-tag) 10)
+   (add1-tag 10))
+  (check-variant=
+   ((compose/variant variant add1-tag variant) 10)
+   (add1-tag 10)))
+

--- a/tests/variant.rkt
+++ b/tests/variant.rkt
@@ -44,6 +44,33 @@
   (check-exn exn:fail:contract?
              (λ () (call-with-variant (λ () (variant 'a 'b #:tag 1)) cons))))
 
+(test-case "Test `compose/variant'"
+  (define (add1-tag x) (variant (add1 x) #:tag 1))
+  (define (unwrap #:tag [n 0] x) (cons x n))
+  (check-variant=
+   ((compose/variant) #:tag 2 1 2)
+   (variant 1 2 #:tag 2))
+  (check-variant=
+   ((compose/variant add1-tag values) 3)
+   (variant 4 #:tag 1))
+  (check-equal?
+   ((compose/variant unwrap add1-tag) 3)
+   '(4 . 1))
+  (define (inc #:tag [n 0] x) (variant (add1 x) #:tag n))
+  (define (pair #:tag [n 0] x) (cons x n))
+  (check-equal?
+   ((compose/variant pair inc) #:tag 5 1)
+   '(2 . 5))
+  (check-variant=
+   ((compose/variant add1-tag variant) 10)
+   (add1-tag 10))
+  (check-variant=
+   ((compose/variant variant add1-tag) 10)
+   (add1-tag 10))
+  (check-variant=
+   ((compose/variant variant add1-tag variant) 10)
+   (add1-tag 10)))
+
 (test-case "Test `let*-variant'"
   (check-equal? (let*-variant ([v* (variant 1 2 3)]) v*) '(1 2 3))
   (check-equal? (let*-variant ([(v . v*) (variant 1 2 3)]) (cons v* v))
@@ -87,31 +114,3 @@
              (λ ()
                (define-variant (#:tag n v . v*) (variant 1 2 3 #:tag 0))
                (cons (cons v* v) n))))
-
-(test-case "Test `compose/variant'"
-  (define (add1-tag x) (variant (add1 x) #:tag 1))
-  (define (unwrap #:tag [n 0] x) (cons x n))
-  (check-variant=
-   ((compose/variant) #:tag 2 1 2)
-   (variant 1 2 #:tag 2))
-  (check-variant=
-   ((compose/variant add1-tag values) 3)
-   (variant 4 #:tag 1))
-  (check-equal?
-   ((compose/variant unwrap add1-tag) 3)
-   '(4 . 1))
-  (define (inc #:tag [n 0] x) (variant (add1 x) #:tag n))
-  (define (pair #:tag [n 0] x) (cons x n))
-  (check-equal?
-   ((compose/variant pair inc) #:tag 5 1)
-   '(2 . 5))
-  (check-variant=
-   ((compose/variant add1-tag variant) 10)
-   (add1-tag 10))
-  (check-variant=
-   ((compose/variant variant add1-tag) 10)
-   (add1-tag 10))
-  (check-variant=
-   ((compose/variant variant add1-tag variant) 10)
-   (add1-tag 10)))
-


### PR DESCRIPTION
## Summary
- implement compose/variant with tag-aware closures and identity handling
- mention identity behaviour in docs
- extend compose/variant tests
- refine compose/variant implementation
- fix manual indentation
- switch `eq?` to `equal?` in `compose2/variant`
- wrap long manual line for 80-character style
- name the closure returned by `compose2/variant`
- separate compose/variant paragraphs in manual
- add examples for compose/variant with `variant`
- drop argument from identity examples
- clarify identity example usage

## Testing
- `raco test tests/variant.rkt`

------
https://chatgpt.com/codex/tasks/task_e_685a21cad098832584a9cf141ac43bfe