### PR TITLE
Implement inclusion procedure for variant tags

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -12,10 +12,10 @@
   ;; Contracted functions that make up the public API
   (contract-out
    [variant procedure?]
+   [inclusion (-> integer? (->* () (#:tag natural?) #:rest (listof any/c) any))]
    [apply/variant (->* (procedure?) (#:tag natural?) #:rest (listof any/c) any)]
    [call-with-variant (-> procedure? procedure? any)]
-   [compose/variant (->* () () #:rest (listof procedure?) procedure?)]
-   [inclusion (-> natural? (->* () (#:tag natural?) #:rest (listof any/c) any))])
+   [compose/variant (->* () () #:rest (listof procedure?) procedure?)])
   ;; Export the tag structure type and the helper macros
   (struct-out tag)
   let*-variant
@@ -42,6 +42,12 @@
   (if (zero? n)
       (apply values v*)
       (apply values (tag n) v*)))
+
+(define ((inclusion m) #:tag [n 0] . v*)
+  ;; Additive inclusion for tags.  The returned procedure forwards
+  ;; its incoming tag (defaulting to 0) and adds `n` to it, always
+  ;; producing an explicitly tagged variant.
+  (apply values (tag (+ m n)) v*))
 
 (define (apply/variant proc #:tag [n 0] . v*)
   ;; Like `apply`, but optionally forwards the `#:tag` keyword to
@@ -79,12 +85,6 @@
   (for/fold ([acc variant])
             ([f (in-list f*)])
     (compose2/variant acc f)))
-
-;; Additive inclusion for tags.  The returned procedure forwards its
-;; incoming tag (defaulting to @racket[0]) and adds @racket[n] to it,
-;; always producing an explicitly tagged variant.
-(define ((inclusion n) #:tag [m 0] . v*)
-  (apply values (tag (+ n m)) v*))
 
 
 (begin-for-syntax

--- a/main.rkt
+++ b/main.rkt
@@ -14,7 +14,8 @@
    [variant procedure?]
    [apply/variant (->* (procedure?) (#:tag natural?) #:rest (listof any/c) any)]
    [call-with-variant (-> procedure? procedure? any)]
-   [compose/variant (->* () () #:rest (listof procedure?) procedure?)])
+   [compose/variant (->* () () #:rest (listof procedure?) procedure?)]
+   [inclusion (-> natural? (->* () (#:tag natural?) #:rest (listof any/c) any))])
   ;; Export the tag structure type and the helper macros
   (struct-out tag)
   let*-variant
@@ -78,6 +79,12 @@
   (for/fold ([acc variant])
             ([f (in-list f*)])
     (compose2/variant acc f)))
+
+;; Additive inclusion for tags.  The returned procedure forwards its
+;; incoming tag (defaulting to @racket[0]) and adds @racket[n] to it,
+;; always producing an explicitly tagged variant.
+(define ((inclusion n) #:tag [m 0] . v*)
+  (apply values (tag (+ n m)) v*))
 
 
 (begin-for-syntax

--- a/scribblings/variant.scrbl
+++ b/scribblings/variant.scrbl
@@ -108,6 +108,17 @@ simply yields @racket[f].
 ]
 }
 
+@defproc[(inclusion [n natural?]) procedure?]{
+Adds @racket[n] to the incoming tag and returns a variant with the
+same values.
+
+@variant-examples[
+(call-with-variant
+ (λ () (variant 1 2 3 #:tag 1))
+ (inclusion 2))
+]
+}
+
 @defform[(let*-variant ([kw-formals rhs-expr] ...) body ...+)
          #:grammar
          [(kw-formals (arg ...)

--- a/scribblings/variant.scrbl
+++ b/scribblings/variant.scrbl
@@ -54,6 +54,16 @@ When @racket[n] is @racket[0] (default), returns plain @tech{values}.
 ]
 }
 
+@defproc[(inclusion [n natural?]) procedure?]{
+Adds @racket[n] to the incoming tag and returns a @tech{tagged values}.
+
+@variant-examples[
+((inclusion 0) 1 2 3)
+((inclusion 1) 1 2 3)
+((inclusion 1) 1 2 3 #:tag 1)
+]
+}
+
 @defproc[(apply/variant [proc procedure?] [v any/c] ... [lst list?] [#:tag n natural? 0]) any]{
 A @tech{variant}-aware version of @racket[apply]. It calls @racket[proc] on
 @racket[(list* v ... lst)], passing @racket[#:tag n] as a normal keyword
@@ -105,17 +115,6 @@ simply yields @racket[f].
 ((compose/variant unwrap add1-tag) 3)
 (compose/variant add1-tag variant)
 (compose/variant variant add1-tag)
-]
-}
-
-@defproc[(inclusion [n natural?]) procedure?]{
-Adds @racket[n] to the incoming tag and returns a variant with the
-same values.
-
-@variant-examples[
-(call-with-variant
- (λ () (variant 1 2 3 #:tag 1))
- (inclusion 2))
 ]
 }
 

--- a/tests/variant.rkt
+++ b/tests/variant.rkt
@@ -113,5 +113,17 @@
                (cons (cons v* v) n)))
   (check-exn exn:fail:contract?
              (λ ()
-               (define-variant (#:tag n v . v*) (variant 1 2 3 #:tag 0))
-               (cons (cons v* v) n))))
+              (define-variant (#:tag n v . v*) (variant 1 2 3 #:tag 0))
+              (cons (cons v* v) n))))
+
+(test-case "Test `inclusion'"
+  (for* ([i (in-range 5)]
+         [n (in-range 10)])
+    (check-equal?
+     (call-with-values
+      (λ ()
+        (call-with-variant
+         (λ () (variant 1 2 3 #:tag i))
+         (inclusion n)))
+      list)
+     (list (tag (+ i n)) 1 2 3))))

--- a/tests/variant.rkt
+++ b/tests/variant.rkt
@@ -125,5 +125,5 @@
                (cons (cons v* v) n)))
   (check-exn exn:fail:contract?
              (λ ()
-              (define-variant (#:tag n v . v*) (variant 1 2 3 #:tag 0))
-              (cons (cons v* v) n))))
+               (define-variant (#:tag n v . v*) (variant 1 2 3 #:tag 0))
+               (cons (cons v* v) n))))

--- a/tests/variant.rkt
+++ b/tests/variant.rkt
@@ -27,6 +27,18 @@
   (check-variant= (variant 1 2 3 #:tag 0) (values (tag 0) 1 2 3))
   (check-variant= (variant 1 2 3 #:tag 1) (values (tag 1) 1 2 3)))
 
+(test-case "Test `inclusion'"
+  (for* ([i (in-range 5)]
+         [n (in-range 10)])
+    (check-equal?
+     (call-with-values
+      (λ ()
+        (call-with-variant
+         (λ () (variant 1 2 3 #:tag i))
+         (inclusion n)))
+      list)
+     (list (tag (+ i n)) 1 2 3))))
+
 (test-case "Test `apply/variant'"
   (check-eqv? (apply/variant + 1 2 (list 3)) 6)
   (check-eqv? (apply/variant + 1 2 (list 3) #:tag 0) 6)
@@ -115,15 +127,3 @@
              (λ ()
               (define-variant (#:tag n v . v*) (variant 1 2 3 #:tag 0))
               (cons (cons v* v) n))))
-
-(test-case "Test `inclusion'"
-  (for* ([i (in-range 5)]
-         [n (in-range 10)])
-    (check-equal?
-     (call-with-values
-      (λ ()
-        (call-with-variant
-         (λ () (variant 1 2 3 #:tag i))
-         (inclusion n)))
-      list)
-     (list (tag (+ i n)) 1 2 3))))


### PR DESCRIPTION
## Summary
- add `inclusion` procedure to add a value to a variant tag
- document `inclusion` in the scribblings
- test `inclusion` behaviour

## Testing
- `raco test tests/variant.rkt`

------
https://chatgpt.com/codex/tasks/task_e_685e03549f78832588b1f9e3dd4f3d01