### PR TITLE
Extend distributivity with tag-based values

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -87,35 +87,43 @@
             ([f (in-list f*)])
     (compose2/variant acc f)))
 
+;; utilities
+(require racket/list)
+
 (define (distributivity #:shape shape . arg*)
   ;; Distribute nested sums over products according to `shape`.
   ;; `shape` is a vector of natural numbers describing the number of
-  ;; options for each argument.  Each argument may optionally start with a
-  ;; `tag` structure indicating which option was chosen.  The result is a
-  ;; single variant tagged with the combined index.
+  ;; options for each argument.  Each argument must begin with a `tag`
+  ;; structure (including @racket[(tag 0)]).  All values until the next
+  ;; tag belong to that argument.  The result is a single variant tagged
+  ;; with the combined index.
   (define len (vector-length shape))
-  (define-values (idx* res*)
-    (for/fold ([idx* '()] [res* '()] [arg* arg*]
+  ;; collect indices in a vector since the length matches `shape`
+  (define idx* (make-vector len))
+  (define res*
+    (for/fold ([arg* arg*] [res* '()]
                #:result
-               (if (pair? arg*)
-                   (raise-arity-error 'distributivity len)
-                   (values (reverse idx*) (reverse res*))))
-              ([size (in-vector shape)])
-      (let-values ([(idx arg*)
-                    (if (and (pair? arg*) (tag? (car arg*)))
-                        (values (tag-number (car arg*)) (cdr arg*))
-                        (values 0 arg*))])
-        (unless (< idx size)
-          (raise-argument-error 'distributivity (format "tag < ~a" size) idx))
-        (unless (pair? arg*)
-          (raise-arity-error 'distributivity len))
-        (values (cons idx idx*)
-                (cons (car arg*) res*)
-                (cdr arg*)))))
+               (begin
+                 (when (pair? arg*)
+                   (raise-arity-error 'distributivity len))
+                 (reverse res*)))
+              ([size (in-vector shape)]
+               [i (in-naturals)])
+      (unless (and (pair? arg*) (tag? (car arg*)))
+        (raise-arity-error 'distributivity len))
+      (define idx (tag-number (car arg*)))
+      (unless (< idx size)
+        (raise-argument-error 'distributivity (format "tag < ~a" size) idx))
+      (define-values (vals rest)
+        (splitf-at (cdr arg*) (λ (x) (not (tag? x)))))
+      (unless (pair? vals)
+        (raise-arity-error 'distributivity len))
+      (vector-set! idx* i idx)
+      (values rest (foldl cons res* vals))))
   ;; compute combined tag using column-major enumeration
   (define tag-num
     (for/fold ([acc 0] [stride 1] #:result acc)
-              ([idx (in-list idx*)]
+              ([idx (in-vector idx*)]
                [size (in-vector shape)])
       (values (+ acc (* idx stride))
               (* stride size))))

--- a/scribblings/variant.scrbl
+++ b/scribblings/variant.scrbl
@@ -120,8 +120,9 @@ simply yields @racket[f].
 
 @defproc[(distributivity [#:shape shape vector?] [v any/c] ...) any]{
 Distributes nested sums over products according to @racket[shape].
-Each argument may optionally start with a @racket[tag] indicating
-which option was chosen. The resulting variant is tagged with the
+Each argument must start with a @racket[tag] (including
+@racket[(tag 0)]) indicating which option was chosen. The resulting
+variant is tagged with the
 combined index in column-major order.
 
 This procedure follows the usual distributive law of multiplication
@@ -136,9 +137,12 @@ over addition.  As an illustration,
 }}
 
 @variant-examples[
-(distributivity #:shape #(1) 'a)
+(distributivity #:shape #(1) (tag 0) 'a)
 (distributivity #:shape #(2) (tag 1) 'b)
-(distributivity #:shape #(1 2) 'a (tag 1) 'c)
+(distributivity #:shape #(1 2) (tag 0) 'a (tag 1) 'c)
+(distributivity #:shape #(2 1)
+                (tag 1) 'a 'b 'c
+                (tag 0) 1 2 3)
 ]
 }
 

--- a/tests/variant.rkt
+++ b/tests/variant.rkt
@@ -87,7 +87,7 @@
 (test-case "Test `distributivity'"
   ;; a
   (check-variant=
-   (distributivity #:shape #(1) 'a)
+   (distributivity #:shape #(1) (tag 0) 'a)
    'a)
   (check-variant=
    (distributivity #:shape #(1) (tag 0) 'a)
@@ -95,7 +95,7 @@
 
   ;; a + b
   (check-variant=
-   (distributivity #:shape #(2) 'a)
+   (distributivity #:shape #(2) (tag 0) 'a)
    'a)
   (check-variant=
    (distributivity #:shape #(2) (tag 1) 'b)
@@ -106,26 +106,26 @@
    (distributivity #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 1) 'a (tag 0) 'b)
+   (distributivity #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 1) (tag 0) 'a 'b)
+   (distributivity #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 1) 'a 'b)
+   (distributivity #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
 
   ;; a × (b + c)
   ;; ≅ a × b
   ;; + a × c
   (check-variant=
-   (distributivity #:shape #(1 2) 'a 'b)
+   (distributivity #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 2) 'a (tag 0) 'b)
+   (distributivity #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 2) 'a (tag 1) 'c)
+   (distributivity #:shape #(1 2) (tag 0) 'a (tag 1) 'c)
    (variant #:tag 1 'a 'c))
 
   ;; a × (b + c + d)
@@ -133,39 +133,56 @@
   ;; + a × c
   ;; + a × d
   (check-variant=
-   (distributivity #:shape #(1 3) 'a 'b)
+   (distributivity #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 3) 'a (tag 0) 'b)
+   (distributivity #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 3) 'a (tag 1) 'c)
+   (distributivity #:shape #(1 3) (tag 0) 'a (tag 1) 'c)
    (variant #:tag 1 'a 'c))
   (check-variant=
-   (distributivity #:shape #(1 3) 'a (tag 2) 'd)
+   (distributivity #:shape #(1 3) (tag 0) 'a (tag 2) 'd)
    (variant #:tag 2 'a 'd))
 
   ;; (a + b) × c
   ;; ≅ a × c + b × c
   (check-variant=
-   (distributivity #:shape #(2 1) 'a 'c)
+   (distributivity #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity #:shape #(2 1) (tag 0) 'a 'c)
+   (distributivity #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity #:shape #(2 1) (tag 1) 'b 'c)
-   (variant #:tag 1 'b 'c))
+  (distributivity #:shape #(2 1) (tag 1) 'b (tag 0) 'c)
+  (variant #:tag 1 'b 'c))
+
+  ;; example with multi-valued arguments starting with tags
+  (check-variant=
+   (distributivity #:shape #(2 1)
+                   (tag 1) 'a 'b 'c
+                   (tag 0) 1 2 3)
+   (variant #:tag 1 'a 'b 'c 1 2 3))
+
+  ;; error cases for missing tags and arity issues
+  (check-exn exn:fail:contract? (λ ()
+                                 (distributivity #:shape #(1) 'a)))
+  (check-exn exn:fail:contract? (λ ()
+                                 (distributivity #:shape #(1) (tag 0))))
+  (check-exn exn:fail:contract? (λ ()
+                                 (distributivity #:shape #(1) (tag 0) 'a (tag 0))))
+  (check-exn exn:fail:contract? (λ ()
+                                 (distributivity #:shape #(1) (tag 2) 'a)))
 
   ;; (a + b) × (c + d) ≅ a × c + b × c + a × d + b × d
   (check-variant=
-   (distributivity #:shape #(2 2) 'a 'c)
+   (distributivity #:shape #(2 2) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity #:shape #(2 2) (tag 1) 'b 'c)
+   (distributivity #:shape #(2 2) (tag 1) 'b (tag 0) 'c)
    (variant #:tag 1 'b 'c))
   (check-variant=
-   (distributivity #:shape #(2 2) 'a (tag 1) 'd)
+   (distributivity #:shape #(2 2) (tag 0) 'a (tag 1) 'd)
    (variant #:tag 2 'a 'd))
   (check-variant=
    (distributivity #:shape #(2 2) (tag 1) 'b (tag 1) 'd)
@@ -179,19 +196,19 @@
   ;; + a × e
   ;; + b × e
   (check-variant=
-   (distributivity #:shape #(2 3) 'a 'c)
+   (distributivity #:shape #(2 3) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity #:shape #(2 3) (tag 1) 'b 'c)
+   (distributivity #:shape #(2 3) (tag 1) 'b (tag 0) 'c)
    (variant #:tag 1 'b 'c))
   (check-variant=
-   (distributivity #:shape #(2 3) 'a (tag 1) 'd)
+   (distributivity #:shape #(2 3) (tag 0) 'a (tag 1) 'd)
    (variant #:tag 2 'a 'd))
   (check-variant=
    (distributivity #:shape #(2 3) (tag 1) 'b (tag 1) 'd)
    (variant #:tag 3 'b 'd))
   (check-variant=
-   (distributivity #:shape #(2 3) 'a (tag 2) 'e)
+   (distributivity #:shape #(2 3) (tag 0) 'a (tag 2) 'e)
    (variant #:tag 4 'a 'e))
   (check-variant=
    (distributivity #:shape #(2 3) (tag 1) 'b (tag 2) 'e)
@@ -200,29 +217,29 @@
   ;; (a + b + c) × d
   ;; ≅ a × d + b × d + c × d
   (check-variant=
-   (distributivity #:shape #(3 1) 'a 'd)
+   (distributivity #:shape #(3 1) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity #:shape #(3 1) (tag 1) 'b 'd)
+   (distributivity #:shape #(3 1) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 1 'b 'd))
   (check-variant=
-   (distributivity #:shape #(3 1) (tag 2) 'c 'd)
+   (distributivity #:shape #(3 1) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 2 'c 'd))
 
   ;; (a + b + c) × (d + e)
   ;; ≅ a × d + b × d + c × d
   ;; + a × e + b × e + c × e
   (check-variant=
-   (distributivity #:shape #(3 2) 'a 'd)
+   (distributivity #:shape #(3 2) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity #:shape #(3 2) (tag 1) 'b 'd)
+   (distributivity #:shape #(3 2) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 1 'b 'd))
   (check-variant=
-   (distributivity #:shape #(3 2) (tag 2) 'c 'd)
+   (distributivity #:shape #(3 2) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 2 'c 'd))
   (check-variant=
-   (distributivity #:shape #(3 2) 'a (tag 1) 'e)
+   (distributivity #:shape #(3 2) (tag 0) 'a (tag 1) 'e)
    (variant #:tag 3 'a 'e))
   (check-variant=
    (distributivity #:shape #(3 2) (tag 1) 'b (tag 1) 'e)
@@ -236,16 +253,16 @@
   ;; + a × e + b × e + c × e
   ;; + a × f + b × f + c × f
   (check-variant=
-   (distributivity #:shape #(3 3) 'a 'd)
+   (distributivity #:shape #(3 3) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity #:shape #(3 3) (tag 1) 'b 'd)
+   (distributivity #:shape #(3 3) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 1 'b 'd))
   (check-variant=
-   (distributivity #:shape #(3 3) (tag 2) 'c 'd)
+   (distributivity #:shape #(3 3) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 2 'c 'd))
   (check-variant=
-   (distributivity #:shape #(3 3) 'a (tag 1) 'e)
+   (distributivity #:shape #(3 3) (tag 0) 'a (tag 1) 'e)
    (variant #:tag 3 'a 'e))
   (check-variant=
    (distributivity #:shape #(3 3) (tag 1) 'b (tag 1) 'e)
@@ -254,7 +271,7 @@
    (distributivity #:shape #(3 3) (tag 2) 'c (tag 1) 'e)
    (variant #:tag 5 'c 'e))
   (check-variant=
-   (distributivity #:shape #(3 3) 'a (tag 2) 'f)
+   (distributivity #:shape #(3 3) (tag 0) 'a (tag 2) 'f)
    (variant #:tag 6 'a 'f))
   (check-variant=
    (distributivity #:shape #(3 3) (tag 1) 'b (tag 2) 'f)


### PR DESCRIPTION
## Summary
- require every argument to `distributivity` to begin with a tag
- split argument lists using `splitf-at`
- document multi-valued example in the manual
- test error cases for missing tags and leftover values
- accumulate values with `cons` instead of `append`
- store argument tags in a vector for clarity
- refactor `distributivity` to use `for/fold`
- address review feedback on `distributivity` (use `in-naturals`)

## Testing
- `raco test tests/variant.rkt`

------
https://chatgpt.com/codex/tasks/task_e_685e19e504e883259ee40cb0d676a60e