### PR TITLE
Add row-major distributivity procedure

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -111,35 +111,35 @@
             (* stride size))))
 
 (define ((make-distributivity enumerator name) #:shape shape . arg*)
-    ;; Distribute nested sums over products according to `shape`.
-    ;; `shape` is a vector of natural numbers describing the number of
-    ;; options for each argument.  Each argument must begin with a `tag`
-    ;; structure (including `(tag 0)`), followed by the values for that
-    ;; argument.  The combined variant uses `enumerator` to compute its tag.
-    (define len (vector-length shape))
-    (define idx* (make-vector len))
-    (define res*
-      (for/fold ([arg* arg*] [res* '()]
-                 #:result
-                 (begin
-                   (unless (null? arg*)
-                     (raise-arity-error name len))
-                   (reverse res*)))
-                ([size (in-vector shape)]
-                 [i (in-naturals)])
-        (unless (and (pair? arg*) (tag? (car arg*)))
-          (raise-arity-error name len))
-        (define idx (tag-number (car arg*)))
-        (unless (< idx size)
-          (raise-argument-error name (format "tag < ~a" size) idx))
-        (define-values (vals args)
-          (splitf-at (cdr arg*) not-tag?))
-        (unless (pair? vals)
-          (raise-arity-error name len))
-        (vector-set! idx* i idx)
-        (values args (foldl cons res* vals))))
-    (define tag-num (enumerator shape idx*))
-    (apply variant #:tag tag-num res*))
+  ;; Distribute nested sums over products according to `shape`.
+  ;; `shape` is a vector of natural numbers describing the number of
+  ;; options for each argument.  Each argument must begin with a `tag`
+  ;; structure (including `(tag 0)`), followed by the values for that
+  ;; argument.  The combined variant uses `enumerator` to compute its tag.
+  (define len (vector-length shape))
+  (define idx* (make-vector len))
+  (define res*
+    (for/fold ([arg* arg*] [res* '()]
+               #:result
+               (begin
+                 (unless (null? arg*)
+                   (raise-arity-error name len))
+                 (reverse res*)))
+              ([size (in-vector shape)]
+               [i (in-naturals)])
+      (unless (and (pair? arg*) (tag? (car arg*)))
+        (raise-arity-error name len))
+      (define idx (tag-number (car arg*)))
+      (unless (< idx size)
+        (raise-argument-error name (format "tag < ~a" size) idx))
+      (define-values (vals args)
+        (splitf-at (cdr arg*) not-tag?))
+      (unless (pair? vals)
+        (raise-arity-error name len))
+      (vector-set! idx* i idx)
+      (values args (foldl cons res* vals))))
+  (define tag-num (enumerator shape idx*))
+  (apply variant #:tag tag-num res*))
 
 (define distributivity/column-major
   (make-distributivity column-major-index 'distributivity/column-major))

--- a/main.rkt
+++ b/main.rkt
@@ -110,8 +110,7 @@
     (values (+ acc (* idx stride))
             (* stride size))))
 
-(define (make-distributivity enumerator name)
-  (λ (#:shape shape . arg*)
+(define ((make-distributivity enumerator name) #:shape shape . arg*)
     ;; Distribute nested sums over products according to `shape`.
     ;; `shape` is a vector of natural numbers describing the number of
     ;; options for each argument.  Each argument must begin with a `tag`
@@ -140,7 +139,7 @@
         (vector-set! idx* i idx)
         (values args (foldl cons res* vals))))
     (define tag-num (enumerator shape idx*))
-    (apply variant #:tag tag-num res*)))
+    (apply variant #:tag tag-num res*))
 
 (define distributivity/column-major
   (make-distributivity column-major-index 'distributivity/column-major))

--- a/main.rkt
+++ b/main.rkt
@@ -17,7 +17,8 @@
    [apply/variant (->* (procedure?) (#:tag natural?) #:rest (listof any/c) any)]
    [call-with-variant (-> procedure? procedure? any)]
    [compose/variant (->* () () #:rest (listof procedure?) procedure?)]
-   [distributivity (->* (#:shape vector?) () #:rest (listof any/c) any)])
+   [distributivity/column-major (->* (#:shape vector?) () #:rest (listof any/c) any)]
+   [distributivity/row-major (->* (#:shape vector?) () #:rest (listof any/c) any)])
   ;; Export the tag structure type and the helper macros
   (struct-out tag)
   let*-variant
@@ -88,7 +89,7 @@
             ([f (in-list f*)])
     (compose2/variant acc f)))
 
-(define (distributivity #:shape shape . arg*)
+(define (distributivity/column-major #:shape shape . arg*)
   ;; Distribute nested sums over products according to `shape`.
   ;; `shape` is a vector of natural numbers describing the number of
   ;; options for each argument.  Each argument must begin with a `tag`
@@ -103,19 +104,19 @@
                #:result
                (begin
                  (unless (null? arg*)
-                   (raise-arity-error 'distributivity len))
+                   (raise-arity-error 'distributivity/column-major len))
                  (reverse res*)))
               ([size (in-vector shape)]
                [i (in-naturals)])
       (unless (and (pair? arg*) (tag? (car arg*)))
-        (raise-arity-error 'distributivity len))
+        (raise-arity-error 'distributivity/column-major len))
       (define idx (tag-number (car arg*)))
       (unless (< idx size)
-        (raise-argument-error 'distributivity (format "tag < ~a" size) idx))
+        (raise-argument-error 'distributivity/column-major (format "tag < ~a" size) idx))
       (define-values (vals args)
         (splitf-at (cdr arg*) not-tag?))
       (unless (pair? vals)
-        (raise-arity-error 'distributivity len))
+        (raise-arity-error 'distributivity/column-major len))
       (vector-set! idx* i idx)
       (values args (foldl cons res* vals))))
   ;; compute combined tag using column-major enumeration
@@ -123,6 +124,42 @@
     (for/fold ([acc 0] [stride 1] #:result acc)
               ([idx (in-vector idx*)]
                [size (in-vector shape)])
+      (values (+ acc (* idx stride))
+              (* stride size))))
+  (apply variant #:tag tag-num res*))
+
+(define (distributivity/row-major #:shape shape . arg*)
+  ;; Distribute nested sums over products according to `shape`.
+  ;; Same semantics as `distributivity/column-major` but the resulting
+  ;; variant uses row-major indexing for its tag.
+  (define len (vector-length shape))
+  (define idx* (make-vector len))
+  (define res*
+    (for/fold ([arg* arg*] [res* '()]
+               #:result
+               (begin
+                 (unless (null? arg*)
+                   (raise-arity-error 'distributivity/row-major len))
+                 (reverse res*)))
+              ([size (in-vector shape)]
+               [i (in-naturals)])
+      (unless (and (pair? arg*) (tag? (car arg*)))
+        (raise-arity-error 'distributivity/row-major len))
+      (define idx (tag-number (car arg*)))
+      (unless (< idx size)
+        (raise-argument-error 'distributivity/row-major (format "tag < ~a" size) idx))
+      (define-values (vals args)
+        (splitf-at (cdr arg*) not-tag?))
+      (unless (pair? vals)
+        (raise-arity-error 'distributivity/row-major len))
+      (vector-set! idx* i idx)
+      (values args (foldl cons res* vals))))
+  ;; compute combined tag using row-major enumeration
+  (define tag-num
+    (for/fold ([acc 0] [stride 1] #:result acc)
+              ([i (in-range (sub1 len) -1 -1)])
+      (define idx (vector-ref idx* i))
+      (define size (vector-ref shape i))
       (values (+ acc (* idx stride))
               (* stride size))))
   (apply variant #:tag tag-num res*))

--- a/main.rkt
+++ b/main.rkt
@@ -17,8 +17,10 @@
    [apply/variant (->* (procedure?) (#:tag natural?) #:rest (listof any/c) any)]
    [call-with-variant (-> procedure? procedure? any)]
    [compose/variant (->* () () #:rest (listof procedure?) procedure?)]
-   [distributivity/column-major (->* (#:shape vector?) () #:rest (listof any/c) any)]
-   [distributivity/row-major (->* (#:shape vector?) () #:rest (listof any/c) any)])
+  [distributivity/column-major
+   (->* (#:shape vector?) () #:rest (listof any/c) any)]
+  [distributivity/row-major
+   (->* (#:shape vector?) () #:rest (listof any/c) any)])
   ;; Export the tag structure type and the helper macros
   (struct-out tag)
   let*-variant
@@ -89,80 +91,62 @@
             ([f (in-list f*)])
     (compose2/variant acc f)))
 
-(define (distributivity/column-major #:shape shape . arg*)
-  ;; Distribute nested sums over products according to `shape`.
-  ;; `shape` is a vector of natural numbers describing the number of
-  ;; options for each argument.  Each argument must begin with a `tag`
-  ;; structure (including `(tag 0)`).  All values until the next
-  ;; tag belong to that argument.  The result is a single variant tagged
-  ;; with the combined index.
-  (define len (vector-length shape))
-  ;; collect indices in a vector since the length matches `shape`
-  (define idx* (make-vector len))
-  (define res*
-    (for/fold ([arg* arg*] [res* '()]
-               #:result
-               (begin
-                 (unless (null? arg*)
-                   (raise-arity-error 'distributivity/column-major len))
-                 (reverse res*)))
-              ([size (in-vector shape)]
-               [i (in-naturals)])
-      (unless (and (pair? arg*) (tag? (car arg*)))
-        (raise-arity-error 'distributivity/column-major len))
-      (define idx (tag-number (car arg*)))
-      (unless (< idx size)
-        (raise-argument-error 'distributivity/column-major (format "tag < ~a" size) idx))
-      (define-values (vals args)
-        (splitf-at (cdr arg*) not-tag?))
-      (unless (pair? vals)
-        (raise-arity-error 'distributivity/column-major len))
-      (vector-set! idx* i idx)
-      (values args (foldl cons res* vals))))
-  ;; compute combined tag using column-major enumeration
-  (define tag-num
-    (for/fold ([acc 0] [stride 1] #:result acc)
-              ([idx (in-vector idx*)]
-               [size (in-vector shape)])
-      (values (+ acc (* idx stride))
-              (* stride size))))
-  (apply variant #:tag tag-num res*))
 
-(define (distributivity/row-major #:shape shape . arg*)
-  ;; Distribute nested sums over products according to `shape`.
-  ;; Same semantics as `distributivity/column-major` but the resulting
-  ;; variant uses row-major indexing for its tag.
+(define (column-major-index shape idx*)
+  ;; Combine indices using column-major enumeration
+  (for/fold ([acc 0] [stride 1] #:result acc)
+            ([idx (in-vector idx*)]
+             [size (in-vector shape)])
+    (values (+ acc (* idx stride))
+            (* stride size))))
+
+(define (row-major-index shape idx*)
+  ;; Combine indices using row-major enumeration
   (define len (vector-length shape))
-  (define idx* (make-vector len))
-  (define res*
-    (for/fold ([arg* arg*] [res* '()]
-               #:result
-               (begin
-                 (unless (null? arg*)
-                   (raise-arity-error 'distributivity/row-major len))
-                 (reverse res*)))
-              ([size (in-vector shape)]
-               [i (in-naturals)])
-      (unless (and (pair? arg*) (tag? (car arg*)))
-        (raise-arity-error 'distributivity/row-major len))
-      (define idx (tag-number (car arg*)))
-      (unless (< idx size)
-        (raise-argument-error 'distributivity/row-major (format "tag < ~a" size) idx))
-      (define-values (vals args)
-        (splitf-at (cdr arg*) not-tag?))
-      (unless (pair? vals)
-        (raise-arity-error 'distributivity/row-major len))
-      (vector-set! idx* i idx)
-      (values args (foldl cons res* vals))))
-  ;; compute combined tag using row-major enumeration
-  (define tag-num
-    (for/fold ([acc 0] [stride 1] #:result acc)
-              ([i (in-range (sub1 len) -1 -1)])
-      (define idx (vector-ref idx* i))
-      (define size (vector-ref shape i))
-      (values (+ acc (* idx stride))
-              (* stride size))))
-  (apply variant #:tag tag-num res*))
+  (for/fold ([acc 0] [stride 1] #:result acc)
+            ([i (in-range (sub1 len) -1 -1)])
+    (define idx (vector-ref idx* i))
+    (define size (vector-ref shape i))
+    (values (+ acc (* idx stride))
+            (* stride size))))
+
+(define (make-distributivity enumerator name)
+  (λ (#:shape shape . arg*)
+    ;; Distribute nested sums over products according to `shape`.
+    ;; `shape` is a vector of natural numbers describing the number of
+    ;; options for each argument.  Each argument must begin with a `tag`
+    ;; structure (including `(tag 0)`), followed by the values for that
+    ;; argument.  The combined variant uses `enumerator` to compute its tag.
+    (define len (vector-length shape))
+    (define idx* (make-vector len))
+    (define res*
+      (for/fold ([arg* arg*] [res* '()]
+                 #:result
+                 (begin
+                   (unless (null? arg*)
+                     (raise-arity-error name len))
+                   (reverse res*)))
+                ([size (in-vector shape)]
+                 [i (in-naturals)])
+        (unless (and (pair? arg*) (tag? (car arg*)))
+          (raise-arity-error name len))
+        (define idx (tag-number (car arg*)))
+        (unless (< idx size)
+          (raise-argument-error name (format "tag < ~a" size) idx))
+        (define-values (vals args)
+          (splitf-at (cdr arg*) not-tag?))
+        (unless (pair? vals)
+          (raise-arity-error name len))
+        (vector-set! idx* i idx)
+        (values args (foldl cons res* vals))))
+    (define tag-num (enumerator shape idx*))
+    (apply variant #:tag tag-num res*)))
+
+(define distributivity/column-major
+  (make-distributivity column-major-index 'distributivity/column-major))
+
+(define distributivity/row-major
+  (make-distributivity row-major-index 'distributivity/row-major))
 
 (begin-for-syntax
   ;; Syntax classes used by the macro definitions below.  They parse the

--- a/scribblings/variant.scrbl
+++ b/scribblings/variant.scrbl
@@ -160,13 +160,13 @@ computed in row-major order.
 }}
 @variant-examples[
  (distributivity/row-major #:shape #(3 3) (tag 0) 'a0 'a1 (tag 0) 'd0 'd1)
- (distributivity/row-major #:shape #(3 3) (tag 1) 'b0 'b1 (tag 0) 'd0 'd1)
- (distributivity/row-major #:shape #(3 3) (tag 2) 'c0 'c1 (tag 0) 'd0 'd1)
  (distributivity/row-major #:shape #(3 3) (tag 0) 'a0 'a1 (tag 1) 'e0 'e1)
- (distributivity/row-major #:shape #(3 3) (tag 1) 'b0 'b1 (tag 1) 'e0 'e1)
- (distributivity/row-major #:shape #(3 3) (tag 2) 'c0 'c1 (tag 1) 'e0 'e1)
  (distributivity/row-major #:shape #(3 3) (tag 0) 'a0 'a1 (tag 2) 'f0 'f1)
+ (distributivity/row-major #:shape #(3 3) (tag 1) 'b0 'b1 (tag 0) 'd0 'd1)
+ (distributivity/row-major #:shape #(3 3) (tag 1) 'b0 'b1 (tag 1) 'e0 'e1)
  (distributivity/row-major #:shape #(3 3) (tag 1) 'b0 'b1 (tag 2) 'f0 'f1)
+ (distributivity/row-major #:shape #(3 3) (tag 2) 'c0 'c1 (tag 0) 'd0 'd1)
+ (distributivity/row-major #:shape #(3 3) (tag 2) 'c0 'c1 (tag 1) 'e0 'e1)
  (distributivity/row-major #:shape #(3 3) (tag 2) 'c0 'c1 (tag 2) 'f0 'f1)
 ]
 }

--- a/scribblings/variant.scrbl
+++ b/scribblings/variant.scrbl
@@ -118,7 +118,7 @@ simply yields @racket[f].
 ]
 }
 
-@defproc[(distributivity [#:shape shape vector?] [v any/c] ...) any]{
+@defproc[(distributivity/column-major [#:shape shape vector?] [v any/c] ...) any]{
 Distributes nested sums over products according to @racket[shape].
 Each argument must start with a @racket[tag] (including @racket[(tag 0)])
 indicating which option was chosen. The resulting @tech{variant} is tagged
@@ -136,15 +136,38 @@ over addition.  As an illustration:
 }}
 
 @variant-examples[
-(distributivity #:shape #(3 3) (tag 0) 'a0 'a1 (tag 0) 'd0 'd1)
-(distributivity #:shape #(3 3) (tag 1) 'b0 'b1 (tag 0) 'd0 'd1)
-(distributivity #:shape #(3 3) (tag 2) 'c0 'c1 (tag 0) 'd0 'd1)
-(distributivity #:shape #(3 3) (tag 0) 'a0 'a1 (tag 1) 'e0 'e1)
-(distributivity #:shape #(3 3) (tag 1) 'b0 'b1 (tag 1) 'e0 'e1)
-(distributivity #:shape #(3 3) (tag 2) 'c0 'c1 (tag 1) 'e0 'e1)
-(distributivity #:shape #(3 3) (tag 0) 'a0 'a1 (tag 2) 'f0 'f1)
-(distributivity #:shape #(3 3) (tag 1) 'b0 'b1 (tag 2) 'f0 'f1)
-(distributivity #:shape #(3 3) (tag 2) 'c0 'c1 (tag 2) 'f0 'f1)
+(distributivity/column-major #:shape #(3 3) (tag 0) 'a0 'a1 (tag 0) 'd0 'd1)
+(distributivity/column-major #:shape #(3 3) (tag 1) 'b0 'b1 (tag 0) 'd0 'd1)
+(distributivity/column-major #:shape #(3 3) (tag 2) 'c0 'c1 (tag 0) 'd0 'd1)
+(distributivity/column-major #:shape #(3 3) (tag 0) 'a0 'a1 (tag 1) 'e0 'e1)
+(distributivity/column-major #:shape #(3 3) (tag 1) 'b0 'b1 (tag 1) 'e0 'e1)
+(distributivity/column-major #:shape #(3 3) (tag 2) 'c0 'c1 (tag 1) 'e0 'e1)
+(distributivity/column-major #:shape #(3 3) (tag 0) 'a0 'a1 (tag 2) 'f0 'f1)
+(distributivity/column-major #:shape #(3 3) (tag 1) 'b0 'b1 (tag 2) 'f0 'f1)
+(distributivity/column-major #:shape #(3 3) (tag 2) 'c0 'c1 (tag 2) 'f0 'f1)
+]
+}
+
+@defproc[(distributivity/row-major [#:shape shape vector?] [v any/c] ...) any]{
+Similar to @racket[distributivity/column-major], but the resulting index is
+computed in row-major order.
+@centered{
+@math{
+(a + b + c) × (d + e + f)
+≅ a × d + a × e + a × f
++ b × d + b × e + b × f
++ c × d + c × e + c × f
+}}
+@variant-examples[
+ (distributivity/row-major #:shape #(3 3) (tag 0) 'a0 'a1 (tag 0) 'd0 'd1)
+ (distributivity/row-major #:shape #(3 3) (tag 1) 'b0 'b1 (tag 0) 'd0 'd1)
+ (distributivity/row-major #:shape #(3 3) (tag 2) 'c0 'c1 (tag 0) 'd0 'd1)
+ (distributivity/row-major #:shape #(3 3) (tag 0) 'a0 'a1 (tag 1) 'e0 'e1)
+ (distributivity/row-major #:shape #(3 3) (tag 1) 'b0 'b1 (tag 1) 'e0 'e1)
+ (distributivity/row-major #:shape #(3 3) (tag 2) 'c0 'c1 (tag 1) 'e0 'e1)
+ (distributivity/row-major #:shape #(3 3) (tag 0) 'a0 'a1 (tag 2) 'f0 'f1)
+ (distributivity/row-major #:shape #(3 3) (tag 1) 'b0 'b1 (tag 2) 'f0 'f1)
+ (distributivity/row-major #:shape #(3 3) (tag 2) 'c0 'c1 (tag 2) 'f0 'f1)
 ]
 }
 

--- a/tests/variant.rkt
+++ b/tests/variant.rkt
@@ -84,48 +84,48 @@
    ((compose/variant variant add1-tag variant) 10)
    (add1-tag 10)))
 
-(test-case "Test `distributivity'"
+(test-case "Test `distributivity/column-major'"
   ;; a
   (check-variant=
-   (distributivity #:shape #(1) (tag 0) 'a)
+   (distributivity/column-major #:shape #(1) (tag 0) 'a)
    'a)
   (check-variant=
-   (distributivity #:shape #(1) (tag 0) 'a)
+   (distributivity/column-major #:shape #(1) (tag 0) 'a)
    'a)
 
   ;; a + b
   (check-variant=
-   (distributivity #:shape #(2) (tag 0) 'a)
+   (distributivity/column-major #:shape #(2) (tag 0) 'a)
    'a)
   (check-variant=
-   (distributivity #:shape #(2) (tag 1) 'b)
+   (distributivity/column-major #:shape #(2) (tag 1) 'b)
    (variant #:tag 1 'b))
 
   ;; a × b
   (check-variant=
-   (distributivity #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/column-major #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/column-major #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/column-major #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/column-major #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
 
   ;; a × (b + c)
   ;; ≅ a × b
   ;; + a × c
   (check-variant=
-   (distributivity #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
+   (distributivity/column-major #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
+   (distributivity/column-major #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 2) (tag 0) 'a (tag 1) 'c)
+   (distributivity/column-major #:shape #(1 2) (tag 0) 'a (tag 1) 'c)
    (variant #:tag 1 'a 'c))
 
   ;; a × (b + c + d)
@@ -133,44 +133,44 @@
   ;; + a × c
   ;; + a × d
   (check-variant=
-   (distributivity #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
+   (distributivity/column-major #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
+   (distributivity/column-major #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity #:shape #(1 3) (tag 0) 'a (tag 1) 'c)
+   (distributivity/column-major #:shape #(1 3) (tag 0) 'a (tag 1) 'c)
    (variant #:tag 1 'a 'c))
   (check-variant=
-   (distributivity #:shape #(1 3) (tag 0) 'a (tag 2) 'd)
+   (distributivity/column-major #:shape #(1 3) (tag 0) 'a (tag 2) 'd)
    (variant #:tag 2 'a 'd))
 
   ;; (a + b) × c
   ;; ≅ a × c + b × c
   (check-variant=
-   (distributivity #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
+   (distributivity/column-major #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
+   (distributivity/column-major #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-  (distributivity #:shape #(2 1) (tag 1) 'b (tag 0) 'c)
+  (distributivity/column-major #:shape #(2 1) (tag 1) 'b (tag 0) 'c)
   (variant #:tag 1 'b 'c))
 
   ;; (a + b) × (c + d)
   ;; ≅ a × c + b × c
   ;; + a × d + b × d
   (check-variant=
-   (distributivity #:shape #(2 2) (tag 0) 'a (tag 0) 'c)
+   (distributivity/column-major #:shape #(2 2) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity #:shape #(2 2) (tag 1) 'b (tag 0) 'c)
+   (distributivity/column-major #:shape #(2 2) (tag 1) 'b (tag 0) 'c)
    (variant #:tag 1 'b 'c))
   (check-variant=
-   (distributivity #:shape #(2 2) (tag 0) 'a (tag 1) 'd)
+   (distributivity/column-major #:shape #(2 2) (tag 0) 'a (tag 1) 'd)
    (variant #:tag 2 'a 'd))
   (check-variant=
-   (distributivity #:shape #(2 2) (tag 1) 'b (tag 1) 'd)
+   (distributivity/column-major #:shape #(2 2) (tag 1) 'b (tag 1) 'd)
    (variant #:tag 3 'b 'd))
 
   ;; (a + b) × (c + d + e)
@@ -178,56 +178,56 @@
   ;; + a × d + b × d
   ;; + a × e + b × e
   (check-variant=
-   (distributivity #:shape #(2 3) (tag 0) 'a (tag 0) 'c)
+   (distributivity/column-major #:shape #(2 3) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity #:shape #(2 3) (tag 1) 'b (tag 0) 'c)
+   (distributivity/column-major #:shape #(2 3) (tag 1) 'b (tag 0) 'c)
    (variant #:tag 1 'b 'c))
   (check-variant=
-   (distributivity #:shape #(2 3) (tag 0) 'a (tag 1) 'd)
+   (distributivity/column-major #:shape #(2 3) (tag 0) 'a (tag 1) 'd)
    (variant #:tag 2 'a 'd))
   (check-variant=
-   (distributivity #:shape #(2 3) (tag 1) 'b (tag 1) 'd)
+   (distributivity/column-major #:shape #(2 3) (tag 1) 'b (tag 1) 'd)
    (variant #:tag 3 'b 'd))
   (check-variant=
-   (distributivity #:shape #(2 3) (tag 0) 'a (tag 2) 'e)
+   (distributivity/column-major #:shape #(2 3) (tag 0) 'a (tag 2) 'e)
    (variant #:tag 4 'a 'e))
   (check-variant=
-   (distributivity #:shape #(2 3) (tag 1) 'b (tag 2) 'e)
+   (distributivity/column-major #:shape #(2 3) (tag 1) 'b (tag 2) 'e)
    (variant #:tag 5 'b 'e))
 
   ;; (a + b + c) × d
   ;; ≅ a × d + b × d + c × d
   (check-variant=
-   (distributivity #:shape #(3 1) (tag 0) 'a (tag 0) 'd)
+   (distributivity/column-major #:shape #(3 1) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity #:shape #(3 1) (tag 1) 'b (tag 0) 'd)
+   (distributivity/column-major #:shape #(3 1) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 1 'b 'd))
   (check-variant=
-   (distributivity #:shape #(3 1) (tag 2) 'c (tag 0) 'd)
+   (distributivity/column-major #:shape #(3 1) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 2 'c 'd))
 
   ;; (a + b + c) × (d + e)
   ;; ≅ a × d + b × d + c × d
   ;; + a × e + b × e + c × e
   (check-variant=
-   (distributivity #:shape #(3 2) (tag 0) 'a (tag 0) 'd)
+   (distributivity/column-major #:shape #(3 2) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity #:shape #(3 2) (tag 1) 'b (tag 0) 'd)
+   (distributivity/column-major #:shape #(3 2) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 1 'b 'd))
   (check-variant=
-   (distributivity #:shape #(3 2) (tag 2) 'c (tag 0) 'd)
+   (distributivity/column-major #:shape #(3 2) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 2 'c 'd))
   (check-variant=
-   (distributivity #:shape #(3 2) (tag 0) 'a (tag 1) 'e)
+   (distributivity/column-major #:shape #(3 2) (tag 0) 'a (tag 1) 'e)
    (variant #:tag 3 'a 'e))
   (check-variant=
-   (distributivity #:shape #(3 2) (tag 1) 'b (tag 1) 'e)
+   (distributivity/column-major #:shape #(3 2) (tag 1) 'b (tag 1) 'e)
    (variant #:tag 4 'b 'e))
   (check-variant=
-   (distributivity #:shape #(3 2) (tag 2) 'c (tag 1) 'e)
+   (distributivity/column-major #:shape #(3 2) (tag 2) 'c (tag 1) 'e)
    (variant #:tag 5 'c 'e))
 
   ;; (a + b + c) × (d + e + f)
@@ -235,50 +235,244 @@
   ;; + a × e + b × e + c × e
   ;; + a × f + b × f + c × f
   (check-variant=
-   (distributivity #:shape #(3 3) (tag 0) 'a (tag 0) 'd)
+   (distributivity/column-major #:shape #(3 3) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity #:shape #(3 3) (tag 1) 'b (tag 0) 'd)
+   (distributivity/column-major #:shape #(3 3) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 1 'b 'd))
   (check-variant=
-   (distributivity #:shape #(3 3) (tag 2) 'c (tag 0) 'd)
+   (distributivity/column-major #:shape #(3 3) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 2 'c 'd))
   (check-variant=
-   (distributivity #:shape #(3 3) (tag 0) 'a (tag 1) 'e)
+   (distributivity/column-major #:shape #(3 3) (tag 0) 'a (tag 1) 'e)
    (variant #:tag 3 'a 'e))
   (check-variant=
-   (distributivity #:shape #(3 3) (tag 1) 'b (tag 1) 'e)
+   (distributivity/column-major #:shape #(3 3) (tag 1) 'b (tag 1) 'e)
    (variant #:tag 4 'b 'e))
   (check-variant=
-   (distributivity #:shape #(3 3) (tag 2) 'c (tag 1) 'e)
+   (distributivity/column-major #:shape #(3 3) (tag 2) 'c (tag 1) 'e)
    (variant #:tag 5 'c 'e))
   (check-variant=
-   (distributivity #:shape #(3 3) (tag 0) 'a (tag 2) 'f)
+   (distributivity/column-major #:shape #(3 3) (tag 0) 'a (tag 2) 'f)
    (variant #:tag 6 'a 'f))
   (check-variant=
-   (distributivity #:shape #(3 3) (tag 1) 'b (tag 2) 'f)
+   (distributivity/column-major #:shape #(3 3) (tag 1) 'b (tag 2) 'f)
    (variant #:tag 7 'b 'f))
   (check-variant=
-   (distributivity #:shape #(3 3) (tag 2) 'c (tag 2) 'f)
+   (distributivity/column-major #:shape #(3 3) (tag 2) 'c (tag 2) 'f)
    (variant #:tag 8 'c 'f))
 
   ;; example with multi-valued arguments starting with tags
   (check-variant=
-   (distributivity #:shape #(2 1)
+   (distributivity/column-major #:shape #(2 1)
                    (tag 1) 'a 'b 'c
                    (tag 0) 1 2 3)
    (variant #:tag 1 'a 'b 'c 1 2 3))
 
   ;; error cases for missing tags and arity issues
   (check-exn exn:fail:contract?
-             (λ () (distributivity #:shape #(1) 'a)))
+             (λ () (distributivity/column-major #:shape #(1) 'a)))
   (check-exn exn:fail:contract?
-             (λ () (distributivity #:shape #(1) (tag 0))))
+             (λ () (distributivity/column-major #:shape #(1) (tag 0))))
   (check-exn exn:fail:contract?
-             (λ () (distributivity #:shape #(1) (tag 0) 'a (tag 0))))
+             (λ () (distributivity/column-major #:shape #(1) (tag 0) 'a (tag 0))))
   (check-exn exn:fail:contract?
-             (λ () (distributivity #:shape #(1) (tag 2) 'a))))
+            (λ () (distributivity/column-major #:shape #(1) (tag 2) 'a))))
 
+
+(test-case "Test `distributivity/row-major'"
+  ;; a
+  (check-variant=
+   (distributivity/row-major #:shape #(1) (tag 0) 'a)
+   'a)
+  (check-variant=
+   (distributivity/row-major #:shape #(1) (tag 0) 'a)
+   'a)
+
+  ;; a + b
+  (check-variant=
+   (distributivity/row-major #:shape #(2) (tag 0) 'a)
+   'a)
+  (check-variant=
+   (distributivity/row-major #:shape #(2) (tag 1) 'b)
+   (variant #:tag 1 'b))
+
+  ;; a × b
+  (check-variant=
+   (distributivity/row-major #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (values 'a 'b))
+  (check-variant=
+   (distributivity/row-major #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (values 'a 'b))
+  (check-variant=
+   (distributivity/row-major #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (values 'a 'b))
+  (check-variant=
+   (distributivity/row-major #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (values 'a 'b))
+
+  ;; a × (b + c)
+  ;; ≅ a × b
+  ;; + a × c
+  (check-variant=
+   (distributivity/row-major #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
+   (values 'a 'b))
+  (check-variant=
+   (distributivity/row-major #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
+   (values 'a 'b))
+  (check-variant=
+   (distributivity/row-major #:shape #(1 2) (tag 0) 'a (tag 1) 'c)
+   (variant #:tag 1 'a 'c))
+
+  ;; a × (b + c + d)
+  ;; ≅ a × b
+  ;; + a × c
+  ;; + a × d
+  (check-variant=
+   (distributivity/row-major #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
+   (values 'a 'b))
+  (check-variant=
+   (distributivity/row-major #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
+   (values 'a 'b))
+  (check-variant=
+   (distributivity/row-major #:shape #(1 3) (tag 0) 'a (tag 1) 'c)
+   (variant #:tag 1 'a 'c))
+  (check-variant=
+   (distributivity/row-major #:shape #(1 3) (tag 0) 'a (tag 2) 'd)
+   (variant #:tag 2 'a 'd))
+
+  ;; (a + b) × c
+  ;; ≅ a × c + b × c
+  (check-variant=
+   (distributivity/row-major #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
+   (values 'a 'c))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
+   (values 'a 'c))
+  (check-variant=
+  (distributivity/row-major #:shape #(2 1) (tag 1) 'b (tag 0) 'c)
+  (variant #:tag 1 'b 'c))
+
+  ;; (a + b) × (c + d)
+  ;; ≅ a × c + a × d
+  ;; + b × c + b × d
+  (check-variant=
+   (distributivity/row-major #:shape #(2 2) (tag 0) 'a (tag 0) 'c)
+   (values 'a 'c))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 2) (tag 1) 'b (tag 0) 'c)
+   (variant #:tag 2 'b 'c))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 2) (tag 0) 'a (tag 1) 'd)
+   (variant #:tag 1 'a 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 2) (tag 1) 'b (tag 1) 'd)
+   (variant #:tag 3 'b 'd))
+
+  ;; (a + b) × (c + d + e)
+  ;; ≅ a × c + a × d + a × e
+  ;; + b × c + b × d + b × e
+  (check-variant=
+   (distributivity/row-major #:shape #(2 3) (tag 0) 'a (tag 0) 'c)
+   (values 'a 'c))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 3) (tag 1) 'b (tag 0) 'c)
+   (variant #:tag 3 'b 'c))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 3) (tag 0) 'a (tag 1) 'd)
+   (variant #:tag 1 'a 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 3) (tag 1) 'b (tag 1) 'd)
+   (variant #:tag 4 'b 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 3) (tag 0) 'a (tag 2) 'e)
+   (variant #:tag 2 'a 'e))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 3) (tag 1) 'b (tag 2) 'e)
+   (variant #:tag 5 'b 'e))
+
+  ;; (a + b + c) × d
+  ;; ≅ a × d + b × d + c × d
+  (check-variant=
+   (distributivity/row-major #:shape #(3 1) (tag 0) 'a (tag 0) 'd)
+   (values 'a 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 1) (tag 1) 'b (tag 0) 'd)
+   (variant #:tag 1 'b 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 1) (tag 2) 'c (tag 0) 'd)
+   (variant #:tag 2 'c 'd))
+
+  ;; ≅ a × d + a × e
+  ;; + b × d + b × e
+  ;; + c × d + c × e
+  (check-variant=
+   (distributivity/row-major #:shape #(3 2) (tag 0) 'a (tag 0) 'd)
+   (values 'a 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 2) (tag 1) 'b (tag 0) 'd)
+   (variant #:tag 2 'b 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 2) (tag 2) 'c (tag 0) 'd)
+   (variant #:tag 4 'c 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 2) (tag 0) 'a (tag 1) 'e)
+   (variant #:tag 1 'a 'e))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 2) (tag 1) 'b (tag 1) 'e)
+   (variant #:tag 3 'b 'e))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 2) (tag 2) 'c (tag 1) 'e)
+   (variant #:tag 5 'c 'e))
+
+  ;; (a + b + c) × (d + e + f)
+  ;; ≅ a × d + a × e + a × f
+  ;; + b × d + b × e + b × f
+  ;; + c × d + c × e + c × f
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 0) 'a (tag 0) 'd)
+   (values 'a 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 1) 'b (tag 0) 'd)
+   (variant #:tag 3 'b 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 2) 'c (tag 0) 'd)
+   (variant #:tag 6 'c 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 0) 'a (tag 1) 'e)
+   (variant #:tag 1 'a 'e))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 1) 'b (tag 1) 'e)
+   (variant #:tag 4 'b 'e))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 2) 'c (tag 1) 'e)
+   (variant #:tag 7 'c 'e))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 0) 'a (tag 2) 'f)
+   (variant #:tag 2 'a 'f))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 1) 'b (tag 2) 'f)
+   (variant #:tag 5 'b 'f))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 2) 'c (tag 2) 'f)
+   (variant #:tag 8 'c 'f))
+
+  ;; example with multi-valued arguments starting with tags
+  (check-variant=
+   (distributivity/row-major #:shape #(2 1)
+                   (tag 1) 'a 'b 'c
+                   (tag 0) 1 2 3)
+   (variant #:tag 1 'a 'b 'c 1 2 3))
+
+  ;; error cases for missing tags and arity issues
+  (check-exn exn:fail:contract?
+             (λ () (distributivity/row-major #:shape #(1) 'a)))
+  (check-exn exn:fail:contract?
+             (λ () (distributivity/row-major #:shape #(1) (tag 0))))
+  (check-exn exn:fail:contract?
+             (λ () (distributivity/row-major #:shape #(1) (tag 0) 'a (tag 0))))
+  (check-exn exn:fail:contract?
+            (λ () (distributivity/row-major #:shape #(1) (tag 2) 'a))))
 (test-case "Test `let*-variant'"
   (check-equal? (let*-variant ([v* (variant 1 2 3)]) v*) '(1 2 3))
   (check-equal? (let*-variant ([(v . v*) (variant 1 2 3)]) (cons v* v))

--- a/tests/variant.rkt
+++ b/tests/variant.rkt
@@ -360,11 +360,11 @@
    (distributivity/row-major #:shape #(2 2) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity/row-major #:shape #(2 2) (tag 1) 'b (tag 0) 'c)
-   (variant #:tag 2 'b 'c))
-  (check-variant=
    (distributivity/row-major #:shape #(2 2) (tag 0) 'a (tag 1) 'd)
    (variant #:tag 1 'a 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 2) (tag 1) 'b (tag 0) 'c)
+   (variant #:tag 2 'b 'c))
   (check-variant=
    (distributivity/row-major #:shape #(2 2) (tag 1) 'b (tag 1) 'd)
    (variant #:tag 3 'b 'd))
@@ -376,17 +376,17 @@
    (distributivity/row-major #:shape #(2 3) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity/row-major #:shape #(2 3) (tag 1) 'b (tag 0) 'c)
-   (variant #:tag 3 'b 'c))
-  (check-variant=
    (distributivity/row-major #:shape #(2 3) (tag 0) 'a (tag 1) 'd)
    (variant #:tag 1 'a 'd))
   (check-variant=
-   (distributivity/row-major #:shape #(2 3) (tag 1) 'b (tag 1) 'd)
-   (variant #:tag 4 'b 'd))
-  (check-variant=
    (distributivity/row-major #:shape #(2 3) (tag 0) 'a (tag 2) 'e)
    (variant #:tag 2 'a 'e))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 3) (tag 1) 'b (tag 0) 'c)
+   (variant #:tag 3 'b 'c))
+  (check-variant=
+   (distributivity/row-major #:shape #(2 3) (tag 1) 'b (tag 1) 'd)
+   (variant #:tag 4 'b 'd))
   (check-variant=
    (distributivity/row-major #:shape #(2 3) (tag 1) 'b (tag 2) 'e)
    (variant #:tag 5 'b 'e))
@@ -411,17 +411,17 @@
    (distributivity/row-major #:shape #(3 2) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity/row-major #:shape #(3 2) (tag 1) 'b (tag 0) 'd)
-   (variant #:tag 2 'b 'd))
-  (check-variant=
-   (distributivity/row-major #:shape #(3 2) (tag 2) 'c (tag 0) 'd)
-   (variant #:tag 4 'c 'd))
-  (check-variant=
    (distributivity/row-major #:shape #(3 2) (tag 0) 'a (tag 1) 'e)
    (variant #:tag 1 'a 'e))
   (check-variant=
+   (distributivity/row-major #:shape #(3 2) (tag 1) 'b (tag 0) 'd)
+   (variant #:tag 2 'b 'd))
+  (check-variant=
    (distributivity/row-major #:shape #(3 2) (tag 1) 'b (tag 1) 'e)
    (variant #:tag 3 'b 'e))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 2) (tag 2) 'c (tag 0) 'd)
+   (variant #:tag 4 'c 'd))
   (check-variant=
    (distributivity/row-major #:shape #(3 2) (tag 2) 'c (tag 1) 'e)
    (variant #:tag 5 'c 'e))
@@ -434,26 +434,26 @@
    (distributivity/row-major #:shape #(3 3) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity/row-major #:shape #(3 3) (tag 1) 'b (tag 0) 'd)
-   (variant #:tag 3 'b 'd))
-  (check-variant=
-   (distributivity/row-major #:shape #(3 3) (tag 2) 'c (tag 0) 'd)
-   (variant #:tag 6 'c 'd))
-  (check-variant=
    (distributivity/row-major #:shape #(3 3) (tag 0) 'a (tag 1) 'e)
    (variant #:tag 1 'a 'e))
-  (check-variant=
-   (distributivity/row-major #:shape #(3 3) (tag 1) 'b (tag 1) 'e)
-   (variant #:tag 4 'b 'e))
-  (check-variant=
-   (distributivity/row-major #:shape #(3 3) (tag 2) 'c (tag 1) 'e)
-   (variant #:tag 7 'c 'e))
   (check-variant=
    (distributivity/row-major #:shape #(3 3) (tag 0) 'a (tag 2) 'f)
    (variant #:tag 2 'a 'f))
   (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 1) 'b (tag 0) 'd)
+   (variant #:tag 3 'b 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 1) 'b (tag 1) 'e)
+   (variant #:tag 4 'b 'e))
+  (check-variant=
    (distributivity/row-major #:shape #(3 3) (tag 1) 'b (tag 2) 'f)
    (variant #:tag 5 'b 'f))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 2) 'c (tag 0) 'd)
+   (variant #:tag 6 'c 'd))
+  (check-variant=
+   (distributivity/row-major #:shape #(3 3) (tag 2) 'c (tag 1) 'e)
+   (variant #:tag 7 'c 'e))
   (check-variant=
    (distributivity/row-major #:shape #(3 3) (tag 2) 'c (tag 2) 'f)
    (variant #:tag 8 'c 'f))
@@ -474,6 +474,7 @@
              (λ () (distributivity/row-major #:shape #(1) (tag 0) 'a (tag 0))))
   (check-exn exn:fail:contract?
             (λ () (distributivity/row-major #:shape #(1) (tag 2) 'a))))
+
 (test-case "Test `let*-variant'"
   (check-equal? (let*-variant ([v* (variant 1 2 3)]) v*) '(1 2 3))
   (check-equal? (let*-variant ([(v . v*) (variant 1 2 3)]) (cons v* v))

--- a/tests/variant.rkt
+++ b/tests/variant.rkt
@@ -403,6 +403,7 @@
    (distributivity/row-major #:shape #(3 1) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 2 'c 'd))
 
+  ;; (a + b + c) × (d + e)
   ;; ≅ a × d + a × e
   ;; + b × d + b × e
   ;; + c × d + c × e


### PR DESCRIPTION
## Summary
- rename `distributivity` to `distributivity/column-major`
- add new `distributivity/row-major` that computes tags in row-major order
- update docs and tests for the new APIs
- expand docs with row-major math formula and examples
- fix row-major test comments for product enumeration order

## Testing
- `raco test tests/variant.rkt`


------
https://chatgpt.com/codex/tasks/task_e_685e735b8d0c8325b5dbdfdd15bc18cf