### PR TITLE
Update compose/variant comments

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -76,6 +76,9 @@
   (call-with-values generator receiver*))
 
 (define (compose2/variant g f)
+  ;; Compose two procedures while forwarding tags between them.  `g`
+  ;; is applied to the result of `f`, and `variant` acts as the
+  ;; identity element.
   (cond
     [(eq? f variant) g]
     [(eq? g variant) f]
@@ -85,6 +88,9 @@
      composed]))
 
 (define (compose/variant . f*)
+  ;; Compose zero or more procedures right-to-left using
+  ;; `compose2/variant`.  `variant` is the identity element for this
+  ;; composition.
   (for/fold ([acc variant])
             ([f (in-list f*)])
     (compose2/variant acc f)))


### PR DESCRIPTION
## Summary
- revise comments for `compose2/variant` and `compose/variant`
- keep comments inside each definition and clarify identity behavior

## Testing
- `raco test tests`


------
https://chatgpt.com/codex/tasks/task_e_685f70dc02a083259f7246cc6b116d04