### PR TITLE
Rename distributivity operators

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -17,8 +17,8 @@
    [apply/variant (->* (procedure?) (#:tag natural?) #:rest (listof any/c) any)]
    [call-with-variant (-> procedure? procedure? any)]
    [compose/variant (->* () () #:rest (listof procedure?) procedure?)]
-   [distributivity/column (->* (#:shape vector?) () #:rest (listof any/c) any)]
-   [distributivity/row (->* (#:shape vector?) () #:rest (listof any/c) any)])
+   [distributivity/right (->* (#:shape vector?) () #:rest (listof any/c) any)]
+   [distributivity/left (->* (#:shape vector?) () #:rest (listof any/c) any)])
   ;; Export the tag structure type and the helper macros
   (struct-out tag)
   let*-variant
@@ -128,14 +128,14 @@
               (* stride size))))
   (apply variant #:tag n v*))
 
-(define distributivity/column
+(define distributivity/right
   (make-distributivity
-   'distributivity/column
+   'distributivity/right
    (λ (len) (values 0 len 1))))
 
-(define distributivity/row
+(define distributivity/left
   (make-distributivity
-   'distributivity/row
+   'distributivity/left
    (λ (len) (values (sub1 len) -1 -1))))
 
 (begin-for-syntax

--- a/scribblings/variant.scrbl
+++ b/scribblings/variant.scrbl
@@ -118,11 +118,11 @@ simply yields @racket[f].
 ]
 }
 
-@defproc[(distributivity/column [#:shape shape vector?] [v any/c] ...) any]{
+@defproc[(distributivity/right [#:shape shape vector?] [v any/c] ...) any]{
 Distributes nested sums over products according to @racket[shape].
 Each argument must start with a @racket[tag] (including @racket[(tag 0)])
 indicating which option was chosen. The resulting @tech{variant} is tagged
-with the combined index in column-major order.
+with the combined index in column-major order (right distributivity).
 
 This procedure follows the usual distributive law of multiplication
 over addition.  As an illustration:
@@ -136,21 +136,21 @@ over addition.  As an illustration:
 }}
 
 @variant-examples[
-(distributivity/column #:shape #(3 3) 'a0 'a1 (tag 0) 'd0 'd1)
-(distributivity/column #:shape #(3 3) (tag 1) 'b0 'b1 (tag 0) 'd0 'd1)
-(distributivity/column #:shape #(3 3) (tag 2) 'c0 'c1 (tag 0) 'd0 'd1)
-(distributivity/column #:shape #(3 3) 'a0 'a1 (tag 1) 'e0 'e1)
-(distributivity/column #:shape #(3 3) (tag 1) 'b0 'b1 (tag 1) 'e0 'e1)
-(distributivity/column #:shape #(3 3) (tag 2) 'c0 'c1 (tag 1) 'e0 'e1)
-(distributivity/column #:shape #(3 3) 'a0 'a1 (tag 2) 'f0 'f1)
-(distributivity/column #:shape #(3 3) (tag 1) 'b0 'b1 (tag 2) 'f0 'f1)
-(distributivity/column #:shape #(3 3) (tag 2) 'c0 'c1 (tag 2) 'f0 'f1)
+(distributivity/right #:shape #(3 3) 'a0 'a1 (tag 0) 'd0 'd1)
+(distributivity/right #:shape #(3 3) (tag 1) 'b0 'b1 (tag 0) 'd0 'd1)
+(distributivity/right #:shape #(3 3) (tag 2) 'c0 'c1 (tag 0) 'd0 'd1)
+(distributivity/right #:shape #(3 3) 'a0 'a1 (tag 1) 'e0 'e1)
+(distributivity/right #:shape #(3 3) (tag 1) 'b0 'b1 (tag 1) 'e0 'e1)
+(distributivity/right #:shape #(3 3) (tag 2) 'c0 'c1 (tag 1) 'e0 'e1)
+(distributivity/right #:shape #(3 3) 'a0 'a1 (tag 2) 'f0 'f1)
+(distributivity/right #:shape #(3 3) (tag 1) 'b0 'b1 (tag 2) 'f0 'f1)
+(distributivity/right #:shape #(3 3) (tag 2) 'c0 'c1 (tag 2) 'f0 'f1)
 ]
 }
 
-@defproc[(distributivity/row [#:shape shape vector?] [v any/c] ...) any]{
-Similar to @racket[distributivity/column], but the resulting index is
-computed in row-major order.  As an illustration:
+@defproc[(distributivity/left [#:shape shape vector?] [v any/c] ...) any]{
+Similar to @racket[distributivity/right], but the resulting index is
+computed in row-major order (left distributivity).  As an illustration:
 
 @centered{
 @math{
@@ -161,15 +161,15 @@ computed in row-major order.  As an illustration:
 }}
 
 @variant-examples[
- (distributivity/row #:shape #(3 3) 'a0 'a1 (tag 0) 'd0 'd1)
- (distributivity/row #:shape #(3 3) 'a0 'a1 (tag 1) 'e0 'e1)
- (distributivity/row #:shape #(3 3) 'a0 'a1 (tag 2) 'f0 'f1)
- (distributivity/row #:shape #(3 3) (tag 1) 'b0 'b1 (tag 0) 'd0 'd1)
- (distributivity/row #:shape #(3 3) (tag 1) 'b0 'b1 (tag 1) 'e0 'e1)
- (distributivity/row #:shape #(3 3) (tag 1) 'b0 'b1 (tag 2) 'f0 'f1)
- (distributivity/row #:shape #(3 3) (tag 2) 'c0 'c1 (tag 0) 'd0 'd1)
- (distributivity/row #:shape #(3 3) (tag 2) 'c0 'c1 (tag 1) 'e0 'e1)
- (distributivity/row #:shape #(3 3) (tag 2) 'c0 'c1 (tag 2) 'f0 'f1)
+ (distributivity/left #:shape #(3 3) 'a0 'a1 (tag 0) 'd0 'd1)
+ (distributivity/left #:shape #(3 3) 'a0 'a1 (tag 1) 'e0 'e1)
+ (distributivity/left #:shape #(3 3) 'a0 'a1 (tag 2) 'f0 'f1)
+ (distributivity/left #:shape #(3 3) (tag 1) 'b0 'b1 (tag 0) 'd0 'd1)
+ (distributivity/left #:shape #(3 3) (tag 1) 'b0 'b1 (tag 1) 'e0 'e1)
+ (distributivity/left #:shape #(3 3) (tag 1) 'b0 'b1 (tag 2) 'f0 'f1)
+ (distributivity/left #:shape #(3 3) (tag 2) 'c0 'c1 (tag 0) 'd0 'd1)
+ (distributivity/left #:shape #(3 3) (tag 2) 'c0 'c1 (tag 1) 'e0 'e1)
+ (distributivity/left #:shape #(3 3) (tag 2) 'c0 'c1 (tag 2) 'f0 'f1)
 ]
 }
 

--- a/tests/variant.rkt
+++ b/tests/variant.rkt
@@ -84,48 +84,48 @@
    ((compose/variant variant add1-tag variant) 10)
    (add1-tag 10)))
 
-(test-case "Test `distributivity/column'"
+(test-case "Test `distributivity/right'"
   ;; a
   (check-variant=
-   (distributivity/column #:shape #(1) (tag 0) 'a)
+   (distributivity/right #:shape #(1) (tag 0) 'a)
    'a)
   (check-variant=
-   (distributivity/column #:shape #(1) (tag 0) 'a)
+   (distributivity/right #:shape #(1) (tag 0) 'a)
    'a)
 
   ;; a + b
   (check-variant=
-   (distributivity/column #:shape #(2) (tag 0) 'a)
+   (distributivity/right #:shape #(2) (tag 0) 'a)
    'a)
   (check-variant=
-   (distributivity/column #:shape #(2) (tag 1) 'b)
+   (distributivity/right #:shape #(2) (tag 1) 'b)
    (variant #:tag 1 'b))
 
   ;; a × b
   (check-variant=
-   (distributivity/column #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/right #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/column #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/right #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/column #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/right #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/column #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/right #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
 
   ;; a × (b + c)
   ;; ≅ a × b
   ;; + a × c
   (check-variant=
-   (distributivity/column #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
+   (distributivity/right #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/column #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
+   (distributivity/right #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/column #:shape #(1 2) (tag 0) 'a (tag 1) 'c)
+   (distributivity/right #:shape #(1 2) (tag 0) 'a (tag 1) 'c)
    (variant #:tag 1 'a 'c))
 
   ;; a × (b + c + d)
@@ -133,44 +133,44 @@
   ;; + a × c
   ;; + a × d
   (check-variant=
-   (distributivity/column #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
+   (distributivity/right #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/column #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
+   (distributivity/right #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/column #:shape #(1 3) (tag 0) 'a (tag 1) 'c)
+   (distributivity/right #:shape #(1 3) (tag 0) 'a (tag 1) 'c)
    (variant #:tag 1 'a 'c))
   (check-variant=
-   (distributivity/column #:shape #(1 3) (tag 0) 'a (tag 2) 'd)
+   (distributivity/right #:shape #(1 3) (tag 0) 'a (tag 2) 'd)
    (variant #:tag 2 'a 'd))
 
   ;; (a + b) × c
   ;; ≅ a × c + b × c
   (check-variant=
-   (distributivity/column #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
+   (distributivity/right #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity/column #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
+   (distributivity/right #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-  (distributivity/column #:shape #(2 1) (tag 1) 'b (tag 0) 'c)
+  (distributivity/right #:shape #(2 1) (tag 1) 'b (tag 0) 'c)
   (variant #:tag 1 'b 'c))
 
   ;; (a + b) × (c + d)
   ;; ≅ a × c + b × c
   ;; + a × d + b × d
   (check-variant=
-   (distributivity/column #:shape #(2 2) (tag 0) 'a (tag 0) 'c)
+   (distributivity/right #:shape #(2 2) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity/column #:shape #(2 2) (tag 1) 'b (tag 0) 'c)
+   (distributivity/right #:shape #(2 2) (tag 1) 'b (tag 0) 'c)
    (variant #:tag 1 'b 'c))
   (check-variant=
-   (distributivity/column #:shape #(2 2) (tag 0) 'a (tag 1) 'd)
+   (distributivity/right #:shape #(2 2) (tag 0) 'a (tag 1) 'd)
    (variant #:tag 2 'a 'd))
   (check-variant=
-   (distributivity/column #:shape #(2 2) (tag 1) 'b (tag 1) 'd)
+   (distributivity/right #:shape #(2 2) (tag 1) 'b (tag 1) 'd)
    (variant #:tag 3 'b 'd))
 
   ;; (a + b) × (c + d + e)
@@ -178,56 +178,56 @@
   ;; + a × d + b × d
   ;; + a × e + b × e
   (check-variant=
-   (distributivity/column #:shape #(2 3) (tag 0) 'a (tag 0) 'c)
+   (distributivity/right #:shape #(2 3) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity/column #:shape #(2 3) (tag 1) 'b (tag 0) 'c)
+   (distributivity/right #:shape #(2 3) (tag 1) 'b (tag 0) 'c)
    (variant #:tag 1 'b 'c))
   (check-variant=
-   (distributivity/column #:shape #(2 3) (tag 0) 'a (tag 1) 'd)
+   (distributivity/right #:shape #(2 3) (tag 0) 'a (tag 1) 'd)
    (variant #:tag 2 'a 'd))
   (check-variant=
-   (distributivity/column #:shape #(2 3) (tag 1) 'b (tag 1) 'd)
+   (distributivity/right #:shape #(2 3) (tag 1) 'b (tag 1) 'd)
    (variant #:tag 3 'b 'd))
   (check-variant=
-   (distributivity/column #:shape #(2 3) (tag 0) 'a (tag 2) 'e)
+   (distributivity/right #:shape #(2 3) (tag 0) 'a (tag 2) 'e)
    (variant #:tag 4 'a 'e))
   (check-variant=
-   (distributivity/column #:shape #(2 3) (tag 1) 'b (tag 2) 'e)
+   (distributivity/right #:shape #(2 3) (tag 1) 'b (tag 2) 'e)
    (variant #:tag 5 'b 'e))
 
   ;; (a + b + c) × d
   ;; ≅ a × d + b × d + c × d
   (check-variant=
-   (distributivity/column #:shape #(3 1) (tag 0) 'a (tag 0) 'd)
+   (distributivity/right #:shape #(3 1) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity/column #:shape #(3 1) (tag 1) 'b (tag 0) 'd)
+   (distributivity/right #:shape #(3 1) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 1 'b 'd))
   (check-variant=
-   (distributivity/column #:shape #(3 1) (tag 2) 'c (tag 0) 'd)
+   (distributivity/right #:shape #(3 1) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 2 'c 'd))
 
   ;; (a + b + c) × (d + e)
   ;; ≅ a × d + b × d + c × d
   ;; + a × e + b × e + c × e
   (check-variant=
-   (distributivity/column #:shape #(3 2) (tag 0) 'a (tag 0) 'd)
+   (distributivity/right #:shape #(3 2) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity/column #:shape #(3 2) (tag 1) 'b (tag 0) 'd)
+   (distributivity/right #:shape #(3 2) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 1 'b 'd))
   (check-variant=
-   (distributivity/column #:shape #(3 2) (tag 2) 'c (tag 0) 'd)
+   (distributivity/right #:shape #(3 2) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 2 'c 'd))
   (check-variant=
-   (distributivity/column #:shape #(3 2) (tag 0) 'a (tag 1) 'e)
+   (distributivity/right #:shape #(3 2) (tag 0) 'a (tag 1) 'e)
    (variant #:tag 3 'a 'e))
   (check-variant=
-   (distributivity/column #:shape #(3 2) (tag 1) 'b (tag 1) 'e)
+   (distributivity/right #:shape #(3 2) (tag 1) 'b (tag 1) 'e)
    (variant #:tag 4 'b 'e))
   (check-variant=
-   (distributivity/column #:shape #(3 2) (tag 2) 'c (tag 1) 'e)
+   (distributivity/right #:shape #(3 2) (tag 2) 'c (tag 1) 'e)
    (variant #:tag 5 'c 'e))
 
   ;; (a + b + c) × (d + e + f)
@@ -235,89 +235,89 @@
   ;; + a × e + b × e + c × e
   ;; + a × f + b × f + c × f
   (check-variant=
-   (distributivity/column #:shape #(3 3) (tag 0) 'a (tag 0) 'd)
+   (distributivity/right #:shape #(3 3) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity/column #:shape #(3 3) (tag 1) 'b (tag 0) 'd)
+   (distributivity/right #:shape #(3 3) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 1 'b 'd))
   (check-variant=
-   (distributivity/column #:shape #(3 3) (tag 2) 'c (tag 0) 'd)
+   (distributivity/right #:shape #(3 3) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 2 'c 'd))
   (check-variant=
-   (distributivity/column #:shape #(3 3) (tag 0) 'a (tag 1) 'e)
+   (distributivity/right #:shape #(3 3) (tag 0) 'a (tag 1) 'e)
    (variant #:tag 3 'a 'e))
   (check-variant=
-   (distributivity/column #:shape #(3 3) (tag 1) 'b (tag 1) 'e)
+   (distributivity/right #:shape #(3 3) (tag 1) 'b (tag 1) 'e)
    (variant #:tag 4 'b 'e))
   (check-variant=
-   (distributivity/column #:shape #(3 3) (tag 2) 'c (tag 1) 'e)
+   (distributivity/right #:shape #(3 3) (tag 2) 'c (tag 1) 'e)
    (variant #:tag 5 'c 'e))
   (check-variant=
-   (distributivity/column #:shape #(3 3) (tag 0) 'a (tag 2) 'f)
+   (distributivity/right #:shape #(3 3) (tag 0) 'a (tag 2) 'f)
    (variant #:tag 6 'a 'f))
   (check-variant=
-   (distributivity/column #:shape #(3 3) (tag 1) 'b (tag 2) 'f)
+   (distributivity/right #:shape #(3 3) (tag 1) 'b (tag 2) 'f)
    (variant #:tag 7 'b 'f))
   (check-variant=
-   (distributivity/column #:shape #(3 3) (tag 2) 'c (tag 2) 'f)
+   (distributivity/right #:shape #(3 3) (tag 2) 'c (tag 2) 'f)
    (variant #:tag 8 'c 'f))
 
   ;; example with multi-valued arguments starting with tags
   (check-variant=
-   (distributivity/column #:shape #(2 1)
+   (distributivity/right #:shape #(2 1)
                    (tag 1) 'a 'b 'c
                    (tag 0) 1 2 3)
    (variant #:tag 1 'a 'b 'c 1 2 3))
 
   ;; error cases for missing tags and arity issues
   (check-exn exn:fail:contract?
-             (λ () (distributivity/column #:shape #(1) (tag 0) 'a (tag 0))))
+             (λ () (distributivity/right #:shape #(1) (tag 0) 'a (tag 0))))
   (check-exn exn:fail:contract?
-            (λ () (distributivity/column #:shape #(1) (tag 2) 'a))))
+            (λ () (distributivity/right #:shape #(1) (tag 2) 'a))))
 
 
-(test-case "Test `distributivity/row'"
+(test-case "Test `distributivity/left'"
   ;; a
   (check-variant=
-   (distributivity/row #:shape #(1) (tag 0) 'a)
+   (distributivity/left #:shape #(1) (tag 0) 'a)
    'a)
   (check-variant=
-   (distributivity/row #:shape #(1) (tag 0) 'a)
+   (distributivity/left #:shape #(1) (tag 0) 'a)
    'a)
 
   ;; a + b
   (check-variant=
-   (distributivity/row #:shape #(2) (tag 0) 'a)
+   (distributivity/left #:shape #(2) (tag 0) 'a)
    'a)
   (check-variant=
-   (distributivity/row #:shape #(2) (tag 1) 'b)
+   (distributivity/left #:shape #(2) (tag 1) 'b)
    (variant #:tag 1 'b))
 
   ;; a × b
   (check-variant=
-   (distributivity/row #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/left #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/row #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/left #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/row #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/left #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/row #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
+   (distributivity/left #:shape #(1 1) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
 
   ;; a × (b + c)
   ;; ≅ a × b
   ;; + a × c
   (check-variant=
-   (distributivity/row #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
+   (distributivity/left #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/row #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
+   (distributivity/left #:shape #(1 2) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/row #:shape #(1 2) (tag 0) 'a (tag 1) 'c)
+   (distributivity/left #:shape #(1 2) (tag 0) 'a (tag 1) 'c)
    (variant #:tag 1 'a 'c))
 
   ;; a × (b + c + d)
@@ -325,78 +325,78 @@
   ;; + a × c
   ;; + a × d
   (check-variant=
-   (distributivity/row #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
+   (distributivity/left #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/row #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
+   (distributivity/left #:shape #(1 3) (tag 0) 'a (tag 0) 'b)
    (values 'a 'b))
   (check-variant=
-   (distributivity/row #:shape #(1 3) (tag 0) 'a (tag 1) 'c)
+   (distributivity/left #:shape #(1 3) (tag 0) 'a (tag 1) 'c)
    (variant #:tag 1 'a 'c))
   (check-variant=
-   (distributivity/row #:shape #(1 3) (tag 0) 'a (tag 2) 'd)
+   (distributivity/left #:shape #(1 3) (tag 0) 'a (tag 2) 'd)
    (variant #:tag 2 'a 'd))
 
   ;; (a + b) × c
   ;; ≅ a × c + b × c
   (check-variant=
-   (distributivity/row #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
+   (distributivity/left #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity/row #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
+   (distributivity/left #:shape #(2 1) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-  (distributivity/row #:shape #(2 1) (tag 1) 'b (tag 0) 'c)
+  (distributivity/left #:shape #(2 1) (tag 1) 'b (tag 0) 'c)
   (variant #:tag 1 'b 'c))
 
   ;; (a + b) × (c + d)
   ;; ≅ a × c + a × d
   ;; + b × c + b × d
   (check-variant=
-   (distributivity/row #:shape #(2 2) (tag 0) 'a (tag 0) 'c)
+   (distributivity/left #:shape #(2 2) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity/row #:shape #(2 2) (tag 0) 'a (tag 1) 'd)
+   (distributivity/left #:shape #(2 2) (tag 0) 'a (tag 1) 'd)
    (variant #:tag 1 'a 'd))
   (check-variant=
-   (distributivity/row #:shape #(2 2) (tag 1) 'b (tag 0) 'c)
+   (distributivity/left #:shape #(2 2) (tag 1) 'b (tag 0) 'c)
    (variant #:tag 2 'b 'c))
   (check-variant=
-   (distributivity/row #:shape #(2 2) (tag 1) 'b (tag 1) 'd)
+   (distributivity/left #:shape #(2 2) (tag 1) 'b (tag 1) 'd)
    (variant #:tag 3 'b 'd))
 
   ;; (a + b) × (c + d + e)
   ;; ≅ a × c + a × d + a × e
   ;; + b × c + b × d + b × e
   (check-variant=
-   (distributivity/row #:shape #(2 3) (tag 0) 'a (tag 0) 'c)
+   (distributivity/left #:shape #(2 3) (tag 0) 'a (tag 0) 'c)
    (values 'a 'c))
   (check-variant=
-   (distributivity/row #:shape #(2 3) (tag 0) 'a (tag 1) 'd)
+   (distributivity/left #:shape #(2 3) (tag 0) 'a (tag 1) 'd)
    (variant #:tag 1 'a 'd))
   (check-variant=
-   (distributivity/row #:shape #(2 3) (tag 0) 'a (tag 2) 'e)
+   (distributivity/left #:shape #(2 3) (tag 0) 'a (tag 2) 'e)
    (variant #:tag 2 'a 'e))
   (check-variant=
-   (distributivity/row #:shape #(2 3) (tag 1) 'b (tag 0) 'c)
+   (distributivity/left #:shape #(2 3) (tag 1) 'b (tag 0) 'c)
    (variant #:tag 3 'b 'c))
   (check-variant=
-   (distributivity/row #:shape #(2 3) (tag 1) 'b (tag 1) 'd)
+   (distributivity/left #:shape #(2 3) (tag 1) 'b (tag 1) 'd)
    (variant #:tag 4 'b 'd))
   (check-variant=
-   (distributivity/row #:shape #(2 3) (tag 1) 'b (tag 2) 'e)
+   (distributivity/left #:shape #(2 3) (tag 1) 'b (tag 2) 'e)
    (variant #:tag 5 'b 'e))
 
   ;; (a + b + c) × d
   ;; ≅ a × d + b × d + c × d
   (check-variant=
-   (distributivity/row #:shape #(3 1) (tag 0) 'a (tag 0) 'd)
+   (distributivity/left #:shape #(3 1) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity/row #:shape #(3 1) (tag 1) 'b (tag 0) 'd)
+   (distributivity/left #:shape #(3 1) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 1 'b 'd))
   (check-variant=
-   (distributivity/row #:shape #(3 1) (tag 2) 'c (tag 0) 'd)
+   (distributivity/left #:shape #(3 1) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 2 'c 'd))
 
   ;; (a + b + c) × (d + e)
@@ -404,22 +404,22 @@
   ;; + b × d + b × e
   ;; + c × d + c × e
   (check-variant=
-   (distributivity/row #:shape #(3 2) (tag 0) 'a (tag 0) 'd)
+   (distributivity/left #:shape #(3 2) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity/row #:shape #(3 2) (tag 0) 'a (tag 1) 'e)
+   (distributivity/left #:shape #(3 2) (tag 0) 'a (tag 1) 'e)
    (variant #:tag 1 'a 'e))
   (check-variant=
-   (distributivity/row #:shape #(3 2) (tag 1) 'b (tag 0) 'd)
+   (distributivity/left #:shape #(3 2) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 2 'b 'd))
   (check-variant=
-   (distributivity/row #:shape #(3 2) (tag 1) 'b (tag 1) 'e)
+   (distributivity/left #:shape #(3 2) (tag 1) 'b (tag 1) 'e)
    (variant #:tag 3 'b 'e))
   (check-variant=
-   (distributivity/row #:shape #(3 2) (tag 2) 'c (tag 0) 'd)
+   (distributivity/left #:shape #(3 2) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 4 'c 'd))
   (check-variant=
-   (distributivity/row #:shape #(3 2) (tag 2) 'c (tag 1) 'e)
+   (distributivity/left #:shape #(3 2) (tag 2) 'c (tag 1) 'e)
    (variant #:tag 5 'c 'e))
 
   ;; (a + b + c) × (d + e + f)
@@ -427,45 +427,45 @@
   ;; + b × d + b × e + b × f
   ;; + c × d + c × e + c × f
   (check-variant=
-   (distributivity/row #:shape #(3 3) (tag 0) 'a (tag 0) 'd)
+   (distributivity/left #:shape #(3 3) (tag 0) 'a (tag 0) 'd)
    (values 'a 'd))
   (check-variant=
-   (distributivity/row #:shape #(3 3) (tag 0) 'a (tag 1) 'e)
+   (distributivity/left #:shape #(3 3) (tag 0) 'a (tag 1) 'e)
    (variant #:tag 1 'a 'e))
   (check-variant=
-   (distributivity/row #:shape #(3 3) (tag 0) 'a (tag 2) 'f)
+   (distributivity/left #:shape #(3 3) (tag 0) 'a (tag 2) 'f)
    (variant #:tag 2 'a 'f))
   (check-variant=
-   (distributivity/row #:shape #(3 3) (tag 1) 'b (tag 0) 'd)
+   (distributivity/left #:shape #(3 3) (tag 1) 'b (tag 0) 'd)
    (variant #:tag 3 'b 'd))
   (check-variant=
-   (distributivity/row #:shape #(3 3) (tag 1) 'b (tag 1) 'e)
+   (distributivity/left #:shape #(3 3) (tag 1) 'b (tag 1) 'e)
    (variant #:tag 4 'b 'e))
   (check-variant=
-   (distributivity/row #:shape #(3 3) (tag 1) 'b (tag 2) 'f)
+   (distributivity/left #:shape #(3 3) (tag 1) 'b (tag 2) 'f)
    (variant #:tag 5 'b 'f))
   (check-variant=
-   (distributivity/row #:shape #(3 3) (tag 2) 'c (tag 0) 'd)
+   (distributivity/left #:shape #(3 3) (tag 2) 'c (tag 0) 'd)
    (variant #:tag 6 'c 'd))
   (check-variant=
-   (distributivity/row #:shape #(3 3) (tag 2) 'c (tag 1) 'e)
+   (distributivity/left #:shape #(3 3) (tag 2) 'c (tag 1) 'e)
    (variant #:tag 7 'c 'e))
   (check-variant=
-   (distributivity/row #:shape #(3 3) (tag 2) 'c (tag 2) 'f)
+   (distributivity/left #:shape #(3 3) (tag 2) 'c (tag 2) 'f)
    (variant #:tag 8 'c 'f))
 
   ;; example with multi-valued arguments starting with tags
   (check-variant=
-   (distributivity/row #:shape #(2 1)
+   (distributivity/left #:shape #(2 1)
                    (tag 1) 'a 'b 'c
                    (tag 0) 1 2 3)
    (variant #:tag 1 'a 'b 'c 1 2 3))
 
   ;; error cases for missing tags and arity issues
   (check-exn exn:fail:contract?
-             (λ () (distributivity/row #:shape #(1) (tag 0) 'a (tag 0))))
+             (λ () (distributivity/left #:shape #(1) (tag 0) 'a (tag 0))))
   (check-exn exn:fail:contract?
-            (λ () (distributivity/row #:shape #(1) (tag 2) 'a))))
+            (λ () (distributivity/left #:shape #(1) (tag 2) 'a))))
 
 (test-case "Test `let*-variant'"
   (check-equal? (let*-variant ([v* (variant 1 2 3)]) v*) '(1 2 3))


### PR DESCRIPTION
## Summary
- rename `distributivity/column` to `distributivity/right`
- rename `distributivity/row` to `distributivity/left`
- update documentation and examples
- update tests for new names

## Testing
- `raco test tests/variant.rkt`

------
https://chatgpt.com/codex/tasks/task_e_685fd6124bd883259564dfcda12f58ff